### PR TITLE
2024.03.08 Release

### DIFF
--- a/coordinator/coordinator.lua
+++ b/coordinator/coordinator.lua
@@ -302,7 +302,7 @@ function coordinator.comms(version, nic, sv_watchdog)
 
         if not self.sv_linked then
             if self.est_tick_waiting == nil then
-                self.est_start = util.time_s()
+                self.est_start = os.clock()
                 self.est_last = self.est_start
 
                 self.est_tick_waiting, self.est_task_done =
@@ -310,10 +310,10 @@ function coordinator.comms(version, nic, sv_watchdog)
 
                 _send_establish()
             else
-                self.est_tick_waiting(math.max(0, LINK_TIMEOUT - (util.time_s() - self.est_start)))
+                self.est_tick_waiting(math.max(0, LINK_TIMEOUT - (os.clock() - self.est_start)))
             end
 
-            if abort or (util.time_s() - self.est_start) >= LINK_TIMEOUT then
+            if abort or (os.clock() - self.est_start) >= LINK_TIMEOUT then
                 self.est_task_done(false)
 
                 if abort then
@@ -336,9 +336,9 @@ function coordinator.comms(version, nic, sv_watchdog)
             elseif self.sv_config_err then
                 coordinator.log_comms("supervisor unit count does not match coordinator unit count, check configs")
                 ok = false
-            elseif (util.time_s() - self.est_last) > 1.0 then
+            elseif (os.clock() - self.est_last) > 1.0 then
                 _send_establish()
-                self.est_last = util.time_s()
+                self.est_last = os.clock()
             end
         elseif self.est_tick_waiting ~= nil then
             self.est_task_done(true)

--- a/coordinator/coordinator.lua
+++ b/coordinator/coordinator.lua
@@ -95,9 +95,9 @@ function coordinator.load_config()
 
     ---@class monitors_struct
     local monitors = {
-        primary = nil,      ---@type table|nil
-        primary_name = "",
-        flow = nil,         ---@type table|nil
+        main = nil,     ---@type table|nil
+        main_name = "",
+        flow = nil,     ---@type table|nil
         flow_name = "",
         unit_displays = {},
         unit_name_map = {}
@@ -121,11 +121,11 @@ function coordinator.load_config()
                 return 2, "Main monitor is not connected."
             end
 
-            monitors.primary = ppm.get_periph(config.MainDisplay)
-            monitors.primary_name = config.MainDisplay
+            monitors.main = ppm.get_periph(config.MainDisplay)
+            monitors.main_name = config.MainDisplay
 
-            monitors.primary.setTextScale(0.5)
-            w, _ = ppm.monitor_block_size(monitors.primary.getSize())
+            monitors.main.setTextScale(0.5)
+            w, _ = ppm.monitor_block_size(monitors.main.getSize())
             if w ~= 8 then
                 return 2, util.c("Main monitor width is incorrect (was ", w, ", must be 8).")
             end

--- a/coordinator/coordinator.lua
+++ b/coordinator/coordinator.lua
@@ -35,6 +35,7 @@ function coordinator.load_config()
     config.UnitCount = settings.get("UnitCount")
     config.SpeakerVolume = settings.get("SpeakerVolume")
     config.Time24Hour = settings.get("Time24Hour")
+    config.TempScale = settings.get("TempScale")
 
     config.DisableFlowView = settings.get("DisableFlowView")
     config.MainDisplay = settings.get("MainDisplay")
@@ -58,6 +59,8 @@ function coordinator.load_config()
     cfv.assert_type_int(config.UnitCount)
     cfv.assert_range(config.UnitCount, 1, 4)
     cfv.assert_type_bool(config.Time24Hour)
+    cfv.assert_type_int(config.TempScale)
+    cfv.assert_range(config.TempScale, 1, 4)
 
     cfv.assert_type_bool(config.DisableFlowView)
     cfv.assert_type_table(config.UnitDisplays)
@@ -676,7 +679,7 @@ function coordinator.comms(version, nic, sv_watchdog)
 
                                     if conf.num_units == config.UnitCount then
                                         -- init io controller
-                                        iocontrol.init(conf, public)
+                                        iocontrol.init(conf, public, config.TempScale)
 
                                         self.sv_addr = src_addr
                                         self.sv_linked = true

--- a/coordinator/iocontrol.lua
+++ b/coordinator/iocontrol.lua
@@ -47,7 +47,23 @@ end
 -- initialize the coordinator IO controller
 ---@param conf facility_conf configuration
 ---@param comms coord_comms comms reference
-function iocontrol.init(conf, comms)
+---@param temp_scale integer temperature unit (1 = K, 2 = C, 3 = F, 4 = R)
+function iocontrol.init(conf, comms, temp_scale)
+    -- temperature unit label and conversion function (from Kelvin)
+    if temp_scale == 2 then
+        io.temp_label = "\xb0C"
+        io.temp_convert = function (t) return t - 273.15 end
+    elseif temp_scale == 3 then
+        io.temp_label = "\xb0F"
+        io.temp_convert = function (t) return (1.8 * (t - 273.15)) + 32 end
+    elseif temp_scale == 4 then
+        io.temp_label = "\xb0R"
+        io.temp_convert = function (t) return 1.8 * t end
+    else
+        io.temp_label = "K"
+        io.temp_convert = function (t) return t end
+    end
+
     -- facility data structure
     ---@class ioctl_facility
     io.facility = {

--- a/coordinator/iocontrol.lua
+++ b/coordinator/iocontrol.lua
@@ -939,7 +939,7 @@ function iocontrol.update_unit_statuses(statuses)
                         local boil_sum = 0
 
                         for id = 1, #unit.boiler_ps_tbl do
-                            if rtu_statuses.boilers[i] == nil then
+                            if rtu_statuses.boilers[id] == nil then
                                 -- disconnected
                                 unit.boiler_ps_tbl[id].publish("computed_status", 1)
                             end
@@ -982,7 +982,7 @@ function iocontrol.update_unit_statuses(statuses)
                         local flow_sum = 0
 
                         for id = 1, #unit.turbine_ps_tbl do
-                            if rtu_statuses.turbines[i] == nil then
+                            if rtu_statuses.turbines[id] == nil then
                                 -- disconnected
                                 unit.turbine_ps_tbl[id].publish("computed_status", 1)
                             end
@@ -1025,7 +1025,7 @@ function iocontrol.update_unit_statuses(statuses)
                     -- dynamic tank statuses
                     if type(rtu_statuses.tanks) == "table" then
                         for id = 1, #unit.tank_ps_tbl do
-                            if rtu_statuses.tanks[i] == nil then
+                            if rtu_statuses.tanks[id] == nil then
                                 -- disconnected
                                 unit.tank_ps_tbl[id].publish("computed_status", 1)
                             end

--- a/coordinator/renderer.lua
+++ b/coordinator/renderer.lua
@@ -242,43 +242,43 @@ function renderer.ui_ready() return engine.ui_ready end
 function renderer.handle_disconnect(device)
     local is_used = false
 
-    if engine.monitors ~= nil then
-        if engine.monitors.primary == device then
-            if engine.ui.main_display ~= nil then
-                -- delete element tree and clear root UI elements
-                engine.ui.main_display.delete()
-            end
+    if not engine.monitors then return false end
 
-            is_used = true
-            engine.monitors.primary = nil
-            engine.ui.main_display = nil
+    if engine.monitors.primary == device then
+        if engine.ui.main_display ~= nil then
+            -- delete element tree and clear root UI elements
+            engine.ui.main_display.delete()
+        end
 
-            iocontrol.fp_monitor_state("main", false)
-        elseif engine.monitors.flow == device then
-            if engine.ui.flow_display ~= nil then
-                -- delete element tree and clear root UI elements
-                engine.ui.flow_display.delete()
-            end
+        is_used = true
+        engine.monitors.primary = nil
+        engine.ui.main_display = nil
 
-            is_used = true
-            engine.monitors.flow = nil
-            engine.ui.flow_display = nil
+        iocontrol.fp_monitor_state("main", false)
+    elseif engine.monitors.flow == device then
+        if engine.ui.flow_display ~= nil then
+            -- delete element tree and clear root UI elements
+            engine.ui.flow_display.delete()
+        end
 
-            iocontrol.fp_monitor_state("flow", false)
-        else
-            for idx, monitor in pairs(engine.monitors.unit_displays) do
-                if monitor == device then
-                    if engine.ui.unit_displays[idx] ~= nil then
-                        engine.ui.unit_displays[idx].delete()
-                    end
+        is_used = true
+        engine.monitors.flow = nil
+        engine.ui.flow_display = nil
 
-                    is_used = true
-                    engine.monitors.unit_displays[idx] = nil
-                    engine.ui.unit_displays[idx] = nil
-
-                    iocontrol.fp_monitor_state(idx, false)
-                    break
+        iocontrol.fp_monitor_state("flow", false)
+    else
+        for idx, monitor in pairs(engine.monitors.unit_displays) do
+            if monitor == device then
+                if engine.ui.unit_displays[idx] ~= nil then
+                    engine.ui.unit_displays[idx].delete()
                 end
+
+                is_used = true
+                engine.monitors.unit_displays[idx] = nil
+                engine.ui.unit_displays[idx] = nil
+
+                iocontrol.fp_monitor_state(idx, false)
+                break
             end
         end
     end
@@ -293,52 +293,32 @@ end
 function renderer.handle_reconnect(name, device)
     local is_used = false
 
-    if engine.monitors ~= nil then
-        if engine.monitors.primary_name == name then
-            is_used = true
-            _init_display(device)
-            engine.monitors.primary = device
+    if not engine.monitors then return false end
 
-            local disp_x, disp_y = engine.monitors.primary.getSize()
-            engine.dmesg_window.reposition(1, 1, disp_x, disp_y, engine.monitors.primary)
+    -- note: handle_resize is a more adaptive way of re-initializing a connected monitor
+    --       since it can handle a monitor being reconnected that isn't the right size
 
-            if engine.ui_ready and (engine.ui.main_display == nil) then
-                engine.dmesg_window.setVisible(false)
+    if engine.monitors.primary_name == name then
+        is_used = true
+        engine.monitors.primary = device
 
-                engine.ui.main_display = DisplayBox{window=device,fg_bg=style.root}
-                main_view(engine.ui.main_display)
-            else
-                engine.dmesg_window.setVisible(true)
-                engine.dmesg_window.redraw()
-            end
+        local disp_x, disp_y = engine.monitors.primary.getSize()
+        engine.dmesg_window.reposition(1, 1, disp_x, disp_y, engine.monitors.primary)
 
-            iocontrol.fp_monitor_state("main", true)
-        elseif engine.monitors.flow_name == name then
-            is_used = true
-            _init_display(device)
-            engine.monitors.flow = device
+        renderer.handle_resize(name)
+    elseif engine.monitors.flow_name == name then
+        is_used = true
+        engine.monitors.flow = device
 
-            if engine.ui_ready and (engine.ui.flow_display == nil) then
-                engine.ui.flow_display = DisplayBox{window=device,fg_bg=style.root}
-                flow_view(engine.ui.flow_display)
-            end
+        renderer.handle_resize(name)
+    else
+        for idx, monitor in ipairs(engine.monitors.unit_name_map) do
+            if monitor == name then
+                is_used = true
+                engine.monitors.unit_displays[idx] = device
 
-            iocontrol.fp_monitor_state("flow", true)
-        else
-            for idx, monitor in ipairs(engine.monitors.unit_name_map) do
-                if monitor == name then
-                    is_used = true
-                    _init_display(device)
-                    engine.monitors.unit_displays[idx] = device
-
-                    if engine.ui_ready and (engine.ui.unit_displays[idx] == nil) then
-                        engine.ui.unit_displays[idx] = DisplayBox{window=device,fg_bg=style.root}
-                        unit_view(engine.ui.unit_displays[idx], idx)
-                    end
-
-                    iocontrol.fp_monitor_state(idx, true)
-                    break
-                end
+                renderer.handle_resize(name)
+                break
             end
         end
     end
@@ -346,6 +326,151 @@ function renderer.handle_reconnect(name, device)
     return is_used
 end
 
+-- handle a monitor being resized<br>
+-- returns if this monitor is assigned + if the assigned screen still fits
+---@param name string monitor name
+---@return boolean is_used, boolean is_ok
+function renderer.handle_resize(name)
+    local is_used = false
+    local is_ok = true
+    local ui = engine.ui
+
+    if not engine.monitors then return false, false end
+
+    if engine.monitors.primary_name == name and engine.monitors.primary then
+        local device = engine.monitors.primary  ---@type table
+
+        -- this is necessary if the bottom left block was broken and on reconnect
+        _init_display(device)
+
+        is_used = true
+
+        -- resize dmesg window if needed, but don't make it thinner
+        local disp_w, disp_h = engine.monitors.primary.getSize()
+        local dmsg_w, dmsg_h = engine.dmesg_window.getSize()
+        if disp_h ~= dmsg_h then
+            engine.dmesg_window = window.reposition(1, 1, math.max(disp_w, dmsg_w), disp_h, engine.monitors.primary)
+        end
+
+        if ui.main_display then
+            ui.main_display.delete()
+            ui.main_display = nil
+        end
+
+        iocontrol.fp_monitor_state("main", true)
+
+        engine.dmesg_window.setVisible(not engine.ui_ready)
+
+        if engine.ui_ready then
+            local ok = pcall(function ()
+                ui.main_display = DisplayBox{window=device,fg_bg=style.root}
+                main_view(ui.main_display)
+            end)
+
+            if not ok then
+                if ui.main_display then
+                    ui.main_display.delete()
+                    ui.main_display = nil
+                end
+
+                device.setCursorPos(1, 1)
+                device.setBackgroundColor(colors.black)
+                device.setTextColor(colors.red)
+                device.clear()
+                device.write("monitor too small")
+
+                iocontrol.fp_monitor_state("main", false)
+                is_ok = false
+            end
+        else engine.dmesg_window.redraw() end
+    elseif engine.monitors.flow_name == name and engine.monitors.flow then
+        local device = engine.monitors.flow ---@type table
+
+        -- this is necessary if the bottom left block was broken and on reconnect
+        _init_display(device)
+
+        is_used = true
+
+        if ui.flow_display then
+            ui.flow_display.delete()
+            ui.flow_display = nil
+        end
+
+        iocontrol.fp_monitor_state("flow", true)
+
+        if engine.ui_ready then
+            engine.dmesg_window.setVisible(false)
+
+            local ok = pcall(function ()
+                ui.flow_display = DisplayBox{window=device,fg_bg=style.root}
+                flow_view(ui.flow_display)
+            end)
+
+            if not ok then
+                if ui.flow_display then
+                    ui.flow_display.delete()
+                    ui.flow_display = nil
+                end
+
+                device.setCursorPos(1, 1)
+                device.setBackgroundColor(colors.black)
+                device.setTextColor(colors.red)
+                device.clear()
+                device.write("monitor too small")
+
+                iocontrol.fp_monitor_state("flow", false)
+                is_ok = false
+            end
+        end
+    else
+        for idx, monitor in ipairs(engine.monitors.unit_name_map) do
+            local device = engine.monitors.unit_displays[idx]
+
+            if monitor == name and device then
+                -- this is necessary if the bottom left block was broken and on reconnect
+                _init_display(device)
+
+                is_used = true
+
+                if ui.unit_displays[idx] then
+                    ui.unit_displays[idx].delete()
+                    ui.unit_displays[idx] = nil
+                end
+
+                iocontrol.fp_monitor_state(idx, true)
+
+                if engine.ui_ready then
+                    engine.dmesg_window.setVisible(false)
+
+                    local ok = pcall(function ()
+                        ui.unit_displays[idx] = DisplayBox{window=device,fg_bg=style.root}
+                        unit_view(ui.unit_displays[idx], idx)
+                    end)
+
+                    if not ok then
+                        if ui.unit_displays[idx] then
+                            ui.unit_displays[idx].delete()
+                            ui.unit_displays[idx] = nil
+                        end
+
+                        device.setCursorPos(1, 1)
+                        device.setBackgroundColor(colors.black)
+                        device.setTextColor(colors.red)
+                        device.clear()
+                        device.write("monitor too small")
+
+                        iocontrol.fp_monitor_state(idx, false)
+                        is_ok = false
+                    end
+                end
+
+                break
+            end
+        end
+    end
+
+    return is_used, is_ok
+end
 
 -- handle a touch event
 ---@param event mouse_interaction|nil
@@ -355,15 +480,14 @@ function renderer.handle_mouse(event)
             engine.ui.front_panel.handle_mouse(event)
         elseif engine.ui_ready then
             if event.monitor == engine.monitors.primary_name then
-                engine.ui.main_display.handle_mouse(event)
+                if engine.ui.main_display then engine.ui.main_display.handle_mouse(event) end
             elseif event.monitor == engine.monitors.flow_name then
-                engine.ui.flow_display.handle_mouse(event)
+                if engine.ui.flow_display then engine.ui.flow_display.handle_mouse(event) end
             else
                 for id, monitor in ipairs(engine.monitors.unit_name_map) do
-                    if event.monitor == monitor then
-                        local layout = engine.ui.unit_displays[id]  ---@type graphics_element
-                        layout.handle_mouse(event)
-                        break
+                    local display = engine.ui.unit_displays[id]
+                    if event.monitor == monitor and display then
+                        if display then display.handle_mouse(event) end
                     end
                 end
             end

--- a/coordinator/renderer.lua
+++ b/coordinator/renderer.lua
@@ -94,8 +94,8 @@ end
 
 -- initialize the dmesg output window
 function renderer.init_dmesg()
-    local disp_x, disp_y = engine.monitors.primary.getSize()
-    engine.dmesg_window = window.create(engine.monitors.primary, 1, 1, disp_x, disp_y)
+    local disp_w, disp_h = engine.monitors.primary.getSize()
+    engine.dmesg_window = window.create(engine.monitors.primary, 1, 1, disp_w, disp_h)
     log.direct_dmesg(engine.dmesg_window)
 end
 
@@ -302,9 +302,6 @@ function renderer.handle_reconnect(name, device)
         is_used = true
         engine.monitors.primary = device
 
-        local disp_x, disp_y = engine.monitors.primary.getSize()
-        engine.dmesg_window.reposition(1, 1, disp_x, disp_y, engine.monitors.primary)
-
         renderer.handle_resize(name)
     elseif engine.monitors.flow_name == name then
         is_used = true
@@ -347,10 +344,8 @@ function renderer.handle_resize(name)
 
         -- resize dmesg window if needed, but don't make it thinner
         local disp_w, disp_h = engine.monitors.primary.getSize()
-        local dmsg_w, dmsg_h = engine.dmesg_window.getSize()
-        if disp_h ~= dmsg_h then
-            engine.dmesg_window = window.reposition(1, 1, math.max(disp_w, dmsg_w), disp_h, engine.monitors.primary)
-        end
+        local dmsg_w, _ = engine.dmesg_window.getSize()
+        engine.dmesg_window.reposition(1, 1, math.max(disp_w, dmsg_w), disp_h, engine.monitors.primary)
 
         if ui.main_display then
             ui.main_display.delete()

--- a/coordinator/startup.lua
+++ b/coordinator/startup.lua
@@ -22,9 +22,9 @@ local sounder     = require("coordinator.sounder")
 
 local apisessions = require("coordinator.session.apisessions")
 
-local COORDINATOR_VERSION = "v1.2.7"
+local COORDINATOR_VERSION = "v1.2.8"
 
-local CHUNK_LOAD_DELAY_S = 20.0
+local CHUNK_LOAD_DELAY_S = 30.0
 
 local println = util.println
 local println_ts = util.println_ts
@@ -42,24 +42,33 @@ local log_crypto = coordinator.log_crypto
 -- mount connected devices (required for monitor setup)
 ppm.mount_all()
 
+local wait_on_load = true
 local loaded, monitors = coordinator.load_config()
 
 -- if the computer just started, its chunk may have just loaded (...or the user rebooted)
 -- if monitor config failed, maybe an adjacent chunk containing all or part of a monitor has not loaded yet, so keep trying
-while loaded == 2 and os.clock() < CHUNK_LOAD_DELAY_S do
+while wait_on_load and loaded == 2 and os.clock() < CHUNK_LOAD_DELAY_S do
     term.clear()
     term.setCursorPos(1, 1)
     println("There was a monitor configuration problem at boot.\n")
     println("Startup will keep trying every 2s in case of chunk load delays.\n")
     println(util.sprintf("The configurator will be started in %ds if all attempts fail.\n", math.max(0, CHUNK_LOAD_DELAY_S - os.clock())))
-    println("(exit early with ctrl-t)")
+    println("(click to skip to the configurator)")
 
----@diagnostic disable-next-line: undefined-field
-    os.sleep(2)
+    local timer_id = util.start_timer(2)
 
-    -- remount and re-attempt
-    ppm.mount_all()
-    loaded, monitors = coordinator.load_config()
+    while true do
+        local event, param1 = util.pull_event()
+        if event == "timer" and param1 == timer_id then
+            -- remount and re-attempt
+            ppm.mount_all()
+            loaded, monitors = coordinator.load_config()
+            break
+        elseif event == "mouse_click" or event == "terminate" then
+            wait_on_load = false
+            break
+        end
+    end
 end
 
 if loaded ~= 0 then

--- a/coordinator/startup.lua
+++ b/coordinator/startup.lua
@@ -22,7 +22,7 @@ local sounder     = require("coordinator.sounder")
 
 local apisessions = require("coordinator.session.apisessions")
 
-local COORDINATOR_VERSION = "v1.2.5"
+local COORDINATOR_VERSION = "v1.2.6"
 
 local println = util.println
 local println_ts = util.println_ts

--- a/coordinator/startup.lua
+++ b/coordinator/startup.lua
@@ -22,7 +22,7 @@ local sounder     = require("coordinator.sounder")
 
 local apisessions = require("coordinator.session.apisessions")
 
-local COORDINATOR_VERSION = "v1.2.9"
+local COORDINATOR_VERSION = "v1.2.10"
 
 local CHUNK_LOAD_DELAY_S = 30.0
 
@@ -76,9 +76,13 @@ if loaded ~= 0 then
     local success, error = configure.configure(loaded, monitors)
     if success then
         loaded, monitors = coordinator.load_config()
-        assert(loaded == 0, util.trinary(loaded == 1, "failed to load valid configuration", "monitor configuration invalid"))
+        if loaded ~= 0 then
+            println(util.trinary(loaded == 2, "monitor configuration invalid", "failed to load a valid configuration") .. ", please reconfigure")
+            return
+        end
     else
-        assert(success, "coordinator configuration error: " .. error)
+        println("configuration error: " .. error)
+        return
     end
 end
 

--- a/coordinator/startup.lua
+++ b/coordinator/startup.lua
@@ -22,7 +22,7 @@ local sounder     = require("coordinator.sounder")
 
 local apisessions = require("coordinator.session.apisessions")
 
-local COORDINATOR_VERSION = "v1.2.2"
+local COORDINATOR_VERSION = "v1.2.3"
 
 local println = util.println
 local println_ts = util.println_ts
@@ -79,8 +79,8 @@ local function main()
     -- system startup
     ----------------------------------------
 
-    -- re-mount devices now that logging is ready
-    ppm.mount_all()
+    -- log mounts now since mounting was done before logging was ready
+    ppm.log_mounts()
 
     -- report versions/init fp PSIL
     iocontrol.init_fp(COORDINATOR_VERSION, comms.version)
@@ -268,6 +268,11 @@ local function main()
                     sounder.reconnect(device)
                     iocontrol.fp_has_speaker(true)
                 end
+            end
+        elseif event == "monitor_resize" then
+            local is_used, is_ok = renderer.handle_resize(param1)
+            if is_used then
+                log_sys(util.c("configured monitor ", param1, " resized, ", util.trinary(is_ok, "display still fits", "display no longer fits")))
             end
         elseif event == "timer" then
             if loop_clock.is_clock(param1) then

--- a/coordinator/startup.lua
+++ b/coordinator/startup.lua
@@ -22,7 +22,7 @@ local sounder     = require("coordinator.sounder")
 
 local apisessions = require("coordinator.session.apisessions")
 
-local COORDINATOR_VERSION = "v1.2.10"
+local COORDINATOR_VERSION = "v1.2.11"
 
 local CHUNK_LOAD_DELAY_S = 30.0
 

--- a/coordinator/startup.lua
+++ b/coordinator/startup.lua
@@ -22,7 +22,9 @@ local sounder     = require("coordinator.sounder")
 
 local apisessions = require("coordinator.session.apisessions")
 
-local COORDINATOR_VERSION = "v1.2.6"
+local COORDINATOR_VERSION = "v1.2.7"
+
+local CHUNK_LOAD_DELAY_S = 20.0
 
 local println = util.println
 local println_ts = util.println_ts
@@ -41,6 +43,25 @@ local log_crypto = coordinator.log_crypto
 ppm.mount_all()
 
 local loaded, monitors = coordinator.load_config()
+
+-- if the computer just started, its chunk may have just loaded (...or the user rebooted)
+-- if monitor config failed, maybe an adjacent chunk containing all or part of a monitor has not loaded yet, so keep trying
+while loaded == 2 and os.clock() < CHUNK_LOAD_DELAY_S do
+    term.clear()
+    term.setCursorPos(1, 1)
+    println("There was a monitor configuration problem at boot.\n")
+    println("Startup will keep trying every 2s in case of chunk load delays.\n")
+    println(util.sprintf("The configurator will be started in %ds if all attempts fail.\n", math.max(0, CHUNK_LOAD_DELAY_S - os.clock())))
+    println("(exit early with ctrl-t)")
+
+---@diagnostic disable-next-line: undefined-field
+    os.sleep(2)
+
+    -- remount and re-attempt
+    ppm.mount_all()
+    loaded, monitors = coordinator.load_config()
+end
+
 if loaded ~= 0 then
     -- try to reconfigure (user action)
     local success, error = configure.configure(loaded, monitors)

--- a/coordinator/startup.lua
+++ b/coordinator/startup.lua
@@ -22,7 +22,7 @@ local sounder     = require("coordinator.sounder")
 
 local apisessions = require("coordinator.session.apisessions")
 
-local COORDINATOR_VERSION = "v1.2.3"
+local COORDINATOR_VERSION = "v1.2.4"
 
 local println = util.println
 local println_ts = util.println_ts

--- a/coordinator/startup.lua
+++ b/coordinator/startup.lua
@@ -22,7 +22,7 @@ local sounder     = require("coordinator.sounder")
 
 local apisessions = require("coordinator.session.apisessions")
 
-local COORDINATOR_VERSION = "v1.2.8"
+local COORDINATOR_VERSION = "v1.2.9"
 
 local CHUNK_LOAD_DELAY_S = 30.0
 

--- a/coordinator/startup.lua
+++ b/coordinator/startup.lua
@@ -22,7 +22,7 @@ local sounder     = require("coordinator.sounder")
 
 local apisessions = require("coordinator.session.apisessions")
 
-local COORDINATOR_VERSION = "v1.2.4"
+local COORDINATOR_VERSION = "v1.2.5"
 
 local println = util.println
 local println_ts = util.println_ts

--- a/coordinator/ui/components/boiler.lua
+++ b/coordinator/ui/components/boiler.lua
@@ -1,5 +1,7 @@
 local style          = require("coordinator.ui.style")
 
+local iocontrol      = require("coordinator.iocontrol")
+
 local core           = require("graphics.core")
 
 local Rectangle      = require("graphics.elements.rectangle")
@@ -13,6 +15,7 @@ local cpair = core.cpair
 local border = core.border
 
 local text_fg_bg = style.text_colors
+local lu_col = style.lu_colors
 
 -- new boiler view
 ---@param root graphics_element parent
@@ -20,14 +23,16 @@ local text_fg_bg = style.text_colors
 ---@param y integer top left y
 ---@param ps psil ps interface
 local function new_view(root, x, y, ps)
+    local db = iocontrol.get_db()
+
     local boiler = Rectangle{parent=root,border=border(1,colors.gray,true),width=31,height=7,x=x,y=y}
 
     local status = StateIndicator{parent=boiler,x=9,y=1,states=style.boiler.states,value=1,min_width=12}
-    local temp   = DataIndicator{parent=boiler,x=5,y=3,lu_colors=style.lu_col,label="Temp:",unit="K",format="%10.2f",value=0,width=22,fg_bg=text_fg_bg}
-    local boil_r = DataIndicator{parent=boiler,x=5,y=4,lu_colors=style.lu_col,label="Boil:",unit="mB/t",format="%10.0f",value=0,commas=true,width=22,fg_bg=text_fg_bg}
+    local temp   = DataIndicator{parent=boiler,x=5,y=3,lu_colors=lu_col,label="Temp:",unit=db.temp_label,format="%10.2f",value=0,commas=true,width=22,fg_bg=text_fg_bg}
+    local boil_r = DataIndicator{parent=boiler,x=5,y=4,lu_colors=lu_col,label="Boil:",unit="mB/t",format="%10.0f",value=0,commas=true,width=22,fg_bg=text_fg_bg}
 
     status.register(ps, "computed_status", status.update)
-    temp.register(ps, "temperature", temp.update)
+    temp.register(ps, "temperature", function (t) temp.update(db.temp_convert(t)) end)
     boil_r.register(ps, "boil_rate", boil_r.update)
 
     TextBox{parent=boiler,text="H",x=2,y=5,height=1,width=1,fg_bg=text_fg_bg}

--- a/coordinator/ui/components/reactor.lua
+++ b/coordinator/ui/components/reactor.lua
@@ -1,5 +1,7 @@
 local types          = require("scada-common.types")
 
+local iocontrol      = require("coordinator.iocontrol")
+
 local style          = require("coordinator.ui.style")
 
 local core           = require("graphics.core")
@@ -23,15 +25,17 @@ local lu_col = style.lu_colors
 ---@param y integer top left y
 ---@param ps psil ps interface
 local function new_view(root, x, y, ps)
+    local db = iocontrol.get_db()
+
     local reactor = Rectangle{parent=root,border=border(1, colors.gray, true),width=30,height=7,x=x,y=y}
 
     local status    = StateIndicator{parent=reactor,x=6,y=1,states=style.reactor.states,value=1,min_width=16}
-    local core_temp = DataIndicator{parent=reactor,x=2,y=3,lu_colors=lu_col,label="Core Temp:",unit="K",format="%10.2f",value=0,width=26,fg_bg=text_fg_bg}
+    local core_temp = DataIndicator{parent=reactor,x=2,y=3,lu_colors=lu_col,label="Core Temp:",unit=db.temp_label,format="%10.2f",value=0,commas=true,width=26,fg_bg=text_fg_bg}
     local burn_r    = DataIndicator{parent=reactor,x=2,y=4,lu_colors=lu_col,label="Burn Rate:",unit="mB/t",format="%10.2f",value=0,width=26,fg_bg=text_fg_bg}
     local heating_r = DataIndicator{parent=reactor,x=2,y=5,lu_colors=lu_col,label="Heating:",unit="mB/t",format="%12.0f",value=0,commas=true,width=26,fg_bg=text_fg_bg}
 
     status.register(ps, "computed_status", status.update)
-    core_temp.register(ps, "temp", core_temp.update)
+    core_temp.register(ps, "temp", function (t) core_temp.update(db.temp_convert(t)) end)
     burn_r.register(ps, "act_burn_rate", burn_r.update)
     heating_r.register(ps, "heating_rate", heating_r.update)
 

--- a/coordinator/ui/components/unit_detail.lua
+++ b/coordinator/ui/components/unit_detail.lua
@@ -3,6 +3,7 @@
 --
 
 local types             = require("scada-common.types")
+local util              = require("scada-common.util")
 
 local iocontrol         = require("coordinator.iocontrol")
 
@@ -51,8 +52,9 @@ local period = core.flasher.PERIOD
 ---@param parent graphics_element parent
 ---@param id integer
 local function init(parent, id)
-    local unit = iocontrol.get_db().units[id]   ---@type ioctl_unit
-    local f_ps = iocontrol.get_db().facility.ps
+    local db = iocontrol.get_db()
+    local unit = db.units[id]   ---@type ioctl_unit
+    local f_ps = db.facility.ps
 
     local main = Div{parent=parent,x=1,y=1}
 
@@ -114,8 +116,9 @@ local function init(parent, id)
     end)
 
     TextBox{parent=main,x=32,y=22,text="Core Temp",height=1,width=9,fg_bg=style.label}
-    local core_temp = DataIndicator{parent=main,x=32,label="",format="%11.2f",value=0,unit="K",lu_colors=lu_cpair,width=13,fg_bg=bw_fg_bg}
-    core_temp.register(u_ps, "temp", core_temp.update)
+    local fmt = util.trinary(string.len(db.temp_label) == 2, "%10.2f", "%11.2f")
+    local core_temp = DataIndicator{parent=main,x=32,label="",format=fmt,value=0,commas=true,unit=db.temp_label,lu_colors=lu_cpair,width=13,fg_bg=bw_fg_bg}
+    core_temp.register(u_ps, "temp", function (t) core_temp.update(db.temp_convert(t)) end)
 
     TextBox{parent=main,x=32,y=25,text="Burn Rate",height=1,width=9,fg_bg=style.label}
     local act_burn_r = DataIndicator{parent=main,x=32,label="",format="%8.2f",value=0,unit="mB/t",lu_colors=lu_cpair,width=13,fg_bg=bw_fg_bg}

--- a/coordinator/ui/components/unit_flow.lua
+++ b/coordinator/ui/components/unit_flow.lua
@@ -181,10 +181,10 @@ local function make(parent, x, y, wide, unit)
 
     local waste_rate = DataIndicator{parent=waste,x=1,y=3,lu_colors=lu_c,label="",unit="mB/t",format="%7.2f",value=0,width=12,fg_bg=bw_fg_bg}
     local pu_rate = DataIndicator{parent=waste,x=_wide(82,70),y=3,lu_colors=lu_c,label="",unit="mB/t",format="%7.3f",value=0,width=12,fg_bg=bw_fg_bg}
-    local po_rate = DataIndicator{parent=waste,x=_wide(52,45),y=6,lu_colors=lu_c,label="",unit="mB/t",format="%7.3f",value=0,width=12,fg_bg=bw_fg_bg}
-    local popl_rate = DataIndicator{parent=waste,x=_wide(82,70),y=6,lu_colors=lu_c,label="",unit="mB/t",format="%7.3f",value=0,width=12,fg_bg=bw_fg_bg}
-    local poam_rate = DataIndicator{parent=waste,x=_wide(82,70),y=10,lu_colors=lu_c,label="",unit="mB/t",format="%7.3f",value=0,width=12,fg_bg=bw_fg_bg}
-    local spent_rate = DataIndicator{parent=waste,x=_wide(117,99),y=3,lu_colors=lu_c,label="",unit="mB/t",format="%7.3f",value=0,width=12,fg_bg=bw_fg_bg}
+    local po_rate = DataIndicator{parent=waste,x=_wide(52,45),y=6,lu_colors=lu_c,label="",unit="mB/t",format="%7.2f",value=0,width=12,fg_bg=bw_fg_bg}
+    local popl_rate = DataIndicator{parent=waste,x=_wide(82,70),y=6,lu_colors=lu_c,label="",unit="mB/t",format="%7.2f",value=0,width=12,fg_bg=bw_fg_bg}
+    local poam_rate = DataIndicator{parent=waste,x=_wide(82,70),y=10,lu_colors=lu_c,label="",unit="mB/t",format="%7.2f",value=0,width=12,fg_bg=bw_fg_bg}
+    local spent_rate = DataIndicator{parent=waste,x=_wide(117,98),y=3,lu_colors=lu_c,label="",unit="mB/t",format="%8.3f",value=0,width=13,fg_bg=bw_fg_bg}
 
     waste_rate.register(unit.unit_ps, "act_burn_rate", waste_rate.update)
     pu_rate.register(unit.unit_ps, "pu_rate", pu_rate.update)
@@ -214,7 +214,7 @@ local function make(parent, x, y, wide, unit)
     sna_act.register(unit.unit_ps, "po_rate", function (r) sna_act.update(r > 0) end)
     sna_cnt.register(unit.unit_ps, "sna_count", sna_cnt.update)
     sna_pk.register(unit.unit_ps, "sna_peak_rate", sna_pk.update)
-    sna_max.register(unit.unit_ps, "sna_prod_rate", sna_max.update)
+    sna_max.register(unit.unit_ps, "sna_max_rate", sna_max.update)
     sna_in.register(unit.unit_ps, "sna_in", sna_in.update)
 
     return root

--- a/coordinator/ui/layout/flow_view.lua
+++ b/coordinator/ui/layout/flow_view.lua
@@ -348,7 +348,7 @@ local function init(main)
     status.register(facility.sps_ps_tbl[1], "computed_status", status.update)
 
     TextBox{parent=sps_box,x=2,y=3,text="Input Rate",height=1,width=10,fg_bg=style.label}
-    local sps_in = DataIndicator{parent=sps_box,x=2,label="",format="%15.3f",value=0,unit="mB/t",lu_colors=lu_col,width=20,fg_bg=bw_fg_bg}
+    local sps_in = DataIndicator{parent=sps_box,x=2,label="",format="%15.2f",value=0,unit="mB/t",lu_colors=lu_col,width=20,fg_bg=bw_fg_bg}
 
     sps_in.register(facility.ps, "po_am_rate", sps_in.update)
 
@@ -370,8 +370,8 @@ local function init(main)
     TextBox{parent=main,x=145,y=21,text="PROC. WASTE",alignment=ALIGN.CENTER,width=19,height=1,fg_bg=wh_gray}
     local pr_waste  = Rectangle{parent=main,x=145,y=22,border=border(1,colors.gray,true),width=19,height=5,thin=true,fg_bg=bw_fg_bg}
     local pu = DataIndicator{parent=pr_waste,lu_colors=lu_col,label="Pu",unit="mB/t",format="%9.3f",value=0,width=17}
-    local po = DataIndicator{parent=pr_waste,lu_colors=lu_col,label="Po",unit="mB/t",format="%9.3f",value=0,width=17}
-    local popl = DataIndicator{parent=pr_waste,lu_colors=lu_col,label="PoPl",unit="mB/t",format="%7.3f",value=0,width=17}
+    local po = DataIndicator{parent=pr_waste,lu_colors=lu_col,label="Po",unit="mB/t",format="%9.2f",value=0,width=17}
+    local popl = DataIndicator{parent=pr_waste,lu_colors=lu_col,label="PoPl",unit="mB/t",format="%7.2f",value=0,width=17}
 
     pu.register(facility.ps, "pu_rate", pu.update)
     po.register(facility.ps, "po_rate", po.update)

--- a/pocket/startup.lua
+++ b/pocket/startup.lua
@@ -18,7 +18,7 @@ local iocontrol = require("pocket.iocontrol")
 local pocket    = require("pocket.pocket")
 local renderer  = require("pocket.renderer")
 
-local POCKET_VERSION = "v0.7.0-alpha"
+local POCKET_VERSION = "v0.7.1-alpha"
 
 local println = util.println
 local println_ts = util.println_ts
@@ -31,9 +31,13 @@ if not pocket.load_config() then
     -- try to reconfigure (user action)
     local success, error = configure.configure(true)
     if success then
-        assert(pocket.load_config(), "failed to load valid configuration")
+        if not pocket.load_config() then
+            println("failed to load a valid configuration, please reconfigure")
+            return
+        end
     else
-        assert(success, "pocket configuration error: " .. error)
+        println("configuration error: " .. error)
+        return
     end
 end
 

--- a/reactor-plc/databus.lua
+++ b/reactor-plc/databus.lua
@@ -70,7 +70,7 @@ function databus.tx_link_state(state)
 end
 
 -- transmit reactor enable state across the bus
----@param active boolean|nil reactor active
+---@param active any reactor active
 function databus.tx_reactor_state(active)
     databus.ps.publish("reactor_active", active == true)
 end

--- a/reactor-plc/databus.lua
+++ b/reactor-plc/databus.lua
@@ -70,9 +70,9 @@ function databus.tx_link_state(state)
 end
 
 -- transmit reactor enable state across the bus
----@param active boolean reactor active
+---@param active boolean|nil reactor active
 function databus.tx_reactor_state(active)
-    databus.ps.publish("reactor_active", active)
+    databus.ps.publish("reactor_active", active == true)
 end
 
 -- transmit RPS data across the bus

--- a/reactor-plc/plc.lua
+++ b/reactor-plc/plc.lua
@@ -469,11 +469,20 @@ function plc.rps_init(reactor, is_formed)
         self.tripped = false
         self.trip_cause = RPS_TRIP_CAUSE.OK
 
-        for i = 1, #self.state do
-            self.state[i] = false
-        end
+        for i = 1, #self.state do self.state[i] = false end
 
         if not quiet then log.info("RPS: reset") end
+    end
+
+    -- partial RPS reset that only clears fault and sys_fail
+    function public.reset_formed()
+        self.tripped = false
+        self.trip_cause = RPS_TRIP_CAUSE.OK
+
+        self.state[state_keys.fault] = false
+        self.state[state_keys.sys_fail] = false
+
+        log.info("RPS: partial reset on formed")
     end
 
     -- reset the automatic and timeout trip flags, then clear trip if that was the trip cause

--- a/reactor-plc/startup.lua
+++ b/reactor-plc/startup.lua
@@ -18,7 +18,7 @@ local plc       = require("reactor-plc.plc")
 local renderer  = require("reactor-plc.renderer")
 local threads   = require("reactor-plc.threads")
 
-local R_PLC_VERSION = "v1.6.11"
+local R_PLC_VERSION = "v1.6.12"
 
 local println = util.println
 local println_ts = util.println_ts
@@ -131,14 +131,21 @@ local function main()
 
     -- we need a reactor, can at least do some things even if it isn't formed though
     if plc_state.no_reactor then
-        println("init> fission reactor not found");
+        println("init> fission reactor not found")
         log.warning("init> no reactor on startup")
 
         plc_state.init_ok = false
         plc_state.degraded = true
     elseif not smem_dev.reactor.isFormed() then
-        println("init> fission reactor not formed");
+        println("init> fission reactor is not formed")
         log.warning("init> reactor logic adapter present, but reactor is not formed")
+
+        plc_state.degraded = true
+        plc_state.reactor_formed = false
+    elseif smem_dev.reactor.getStatus() == ppm.UNDEFINED_FIELD then
+        -- reactor formed after ppm.mount_all was called
+        println("init> fission reactor was not formed")
+        log.warning("init> reactor reported formed, but multiblock functions are not available")
 
         plc_state.degraded = true
         plc_state.reactor_formed = false

--- a/reactor-plc/startup.lua
+++ b/reactor-plc/startup.lua
@@ -18,7 +18,7 @@ local plc       = require("reactor-plc.plc")
 local renderer  = require("reactor-plc.renderer")
 local threads   = require("reactor-plc.threads")
 
-local R_PLC_VERSION = "v1.6.12"
+local R_PLC_VERSION = "v1.6.13"
 
 local println = util.println
 local println_ts = util.println_ts

--- a/reactor-plc/startup.lua
+++ b/reactor-plc/startup.lua
@@ -18,7 +18,7 @@ local plc       = require("reactor-plc.plc")
 local renderer  = require("reactor-plc.renderer")
 local threads   = require("reactor-plc.threads")
 
-local R_PLC_VERSION = "v1.6.13"
+local R_PLC_VERSION = "v1.6.14"
 
 local println = util.println
 local println_ts = util.println_ts
@@ -31,9 +31,13 @@ if not plc.load_config() then
     -- try to reconfigure (user action)
     local success, error = configure.configure(true)
     if success then
-        assert(plc.load_config(), "failed to load valid configuration")
+        if not plc.load_config() then
+            println("failed to load a valid configuration, please reconfigure")
+            return
+        end
     else
-        assert(success, "reactor PLC configuration error: " .. error)
+        println("configuration error: " .. error)
+        return
     end
 end
 

--- a/reactor-plc/threads.lua
+++ b/reactor-plc/threads.lua
@@ -125,9 +125,8 @@ function threads.thread__main(smem, init)
                                 plc_comms.reconnect_reactor(plc_dev.reactor)
                             end
 
-                            -- reset RPS for newly connected reactor
-                            -- without this, is_formed will be out of date and cause it to think its no longer formed again
-                            rps.reset()
+                            -- partial reset of RPS, specific to becoming formed
+                            rps.reset_formed()
                         else
                             -- fully lost the reactor now :(
                             println_ts("reactor lost (failed reconnect)!")
@@ -231,9 +230,8 @@ function threads.thread__main(smem, init)
                                 plc_comms.reconnect_reactor(plc_dev.reactor)
                             end
 
-                            -- reset RPS for newly connected reactor
-                            -- without this, is_formed will be out of date and cause it to think its no longer formed again
-                            rps.reset()
+                            -- partial reset of RPS, specific to becoming formed
+                            rps.reset_formed()
                         end
                     elseif networked and type == "modem" then
                         -- note, check init_ok first since nic will be nil if it is false

--- a/rtu/startup.lua
+++ b/rtu/startup.lua
@@ -31,7 +31,7 @@ local sna_rtu      = require("rtu.dev.sna_rtu")
 local sps_rtu      = require("rtu.dev.sps_rtu")
 local turbinev_rtu = require("rtu.dev.turbinev_rtu")
 
-local RTU_VERSION = "v1.7.13"
+local RTU_VERSION = "v1.7.14"
 
 local RTU_UNIT_TYPE = types.RTU_UNIT_TYPE
 local RTU_UNIT_HW_STATE = databus.RTU_UNIT_HW_STATE
@@ -47,9 +47,13 @@ if not rtu.load_config() then
     -- try to reconfigure (user action)
     local success, error = configure.configure(true)
     if success then
-        assert(rtu.load_config(), "failed to load valid configuration")
+        if not rtu.load_config() then
+            println("failed to load a valid configuration, please reconfigure")
+            return
+        end
     else
-        assert(success, "RTU configuration error: " .. error)
+        println("configuration error: " .. error)
+        return
     end
 end
 

--- a/scada-common/comms.lua
+++ b/scada-common/comms.lua
@@ -17,7 +17,7 @@ local max_distance = nil
 local comms = {}
 
 -- protocol/data version (protocol/data independent changes tracked by util.lua version)
-comms.version = "2.4.4"
+comms.version = "2.4.5"
 
 ---@enum PROTOCOL
 local PROTOCOL = {

--- a/scada-common/network.lua
+++ b/scada-common/network.lua
@@ -53,6 +53,11 @@ function network.init_mac(passkey)
     return init_time
 end
 
+-- de-initialize message authentication system
+function network.deinit_mac()
+    c_eng.key, c_eng.hmac = nil, nil
+end
+
 -- generate HMAC of message
 ---@nodiscard
 ---@param message string initial value concatenated with ciphertext

--- a/scada-common/ppm.lua
+++ b/scada-common/ppm.lua
@@ -300,6 +300,17 @@ function ppm.handle_unmount(iface)
     return pm_type, pm_dev
 end
 
+-- log all mounts, to be used if `ppm.mount_all` is called before logging is ready
+function ppm.log_mounts()
+    for iface, mount in pairs(ppm_sys.mounts) do
+        log.info(util.c("PPM: had found a ", mount.type, " (", iface, ")"))
+    end
+
+    if #ppm_sys.mounts == 0 then
+        log.warning("PPM: no devices had been found")
+    end
+end
+
 -- GENERAL ACCESSORS --
 
 -- list all available peripherals

--- a/scada-common/ppm.lua
+++ b/scada-common/ppm.lua
@@ -155,7 +155,7 @@ local function peri_init(iface)
 
             self.fault_counts[key] = self.fault_counts[key] + 1
 
-            return (function () return ACCESS_FAULT end)
+            return (function () return UNDEFINED_FIELD end)
         end
     }
 
@@ -306,7 +306,7 @@ function ppm.log_mounts()
         log.info(util.c("PPM: had found a ", mount.type, " (", iface, ")"))
     end
 
-    if #ppm_sys.mounts == 0 then
+    if util.table_len(ppm_sys.mounts) == 0 then
         log.warning("PPM: no devices had been found")
     end
 end

--- a/scada-common/ppm.lua
+++ b/scada-common/ppm.lua
@@ -9,7 +9,7 @@ local util = require("scada-common.util")
 local ppm = {}
 
 local ACCESS_FAULT        = nil                 ---@type nil
-local UNDEFINED_FIELD     = "undefined field"
+local UNDEFINED_FIELD     = "__PPM_UNDEF_FIELD__"
 local VIRTUAL_DEVICE_TYPE = "ppm_vdev"
 
 ppm.ACCESS_FAULT          = ACCESS_FAULT

--- a/scada-common/util.lua
+++ b/scada-common/util.lua
@@ -22,7 +22,7 @@ local t_pack   = table.pack
 local util = {}
 
 -- scada-common version
-util.version = "1.1.14"
+util.version = "1.1.15"
 
 util.TICK_TIME_S = 0.05
 util.TICK_TIME_MS = 50

--- a/scada-common/util.lua
+++ b/scada-common/util.lua
@@ -22,7 +22,7 @@ local t_pack   = table.pack
 local util = {}
 
 -- scada-common version
-util.version = "1.1.17"
+util.version = "1.1.18"
 
 util.TICK_TIME_S = 0.05
 util.TICK_TIME_MS = 50
@@ -284,11 +284,13 @@ function util.cancel_timer(timer) os.cancelTimer(timer) end
 
 --#region PARALLELIZATION
 
--- protected sleep call so we still are in charge of catching termination
----@param t integer seconds
+-- protected sleep call so we still are in charge of catching termination<br>
+-- returns the result of pcall
+---@param t number seconds
+---@return boolean success, any result, any ...
 --- EVENT_CONSUMER: this function consumes events
 ---@diagnostic disable-next-line: undefined-field
-function util.psleep(t) pcall(os.sleep, t) end
+function util.psleep(t) return pcall(os.sleep, t) end
 
 -- no-op to provide a brief pause (1 tick) to yield<br>
 --- EVENT_CONSUMER: this function consumes events

--- a/scada-common/util.lua
+++ b/scada-common/util.lua
@@ -22,7 +22,7 @@ local t_pack   = table.pack
 local util = {}
 
 -- scada-common version
-util.version = "1.1.16"
+util.version = "1.1.17"
 
 util.TICK_TIME_S = 0.05
 util.TICK_TIME_MS = 50

--- a/scada-common/util.lua
+++ b/scada-common/util.lua
@@ -22,7 +22,7 @@ local t_pack   = table.pack
 local util = {}
 
 -- scada-common version
-util.version = "1.1.15"
+util.version = "1.1.16"
 
 util.TICK_TIME_S = 0.05
 util.TICK_TIME_MS = 50

--- a/supervisor/facility.lua
+++ b/supervisor/facility.lua
@@ -337,7 +337,7 @@ function facility.new(num_reactors, cooling_conf)
         if state_changed then
             self.saturated = false
 
-            log.debug("FAC: state changed from " .. PROCESS_NAMES[self.last_mode + 1] .. " to " .. PROCESS_NAMES[self.mode + 1])
+            log.debug(util.c("FAC: state changed from ", PROCESS_NAMES[self.last_mode + 1], " to ", PROCESS_NAMES[self.mode + 1]))
 
             if (self.last_mode == PROCESS.INACTIVE) or (self.last_mode == PROCESS.GEN_RATE_FAULT_IDLE) then
                 self.start_fail = START_STATUS.OK
@@ -374,6 +374,8 @@ function facility.new(num_reactors, cooling_conf)
                         self.max_burn_combined = self.max_burn_combined + (u.get_control_inf().lim_br100 / 100.0)
                     end
                 end
+
+                log.debug(util.c("FAC: computed a max combined burn rate of ", self.max_burn_combined, "mB/t"))
 
                 if blade_count == nil then
                     -- no units
@@ -436,7 +438,7 @@ function facility.new(num_reactors, cooling_conf)
                 self.saturated = true
 
                 self.status_text = { "MONITORED MODE", "running reactors at limit" }
-                log.info(util.c("FAC: MAX_BURN process mode started"))
+                log.info("FAC: MAX_BURN process mode started")
             end
 
             _allocate_burn_rate(self.max_burn_combined, true)
@@ -445,7 +447,7 @@ function facility.new(num_reactors, cooling_conf)
             if state_changed then
                 self.time_start = now
                 self.status_text = { "BURN RATE MODE", "running" }
-                log.info(util.c("FAC: BURN_RATE process mode started"))
+                log.info("FAC: BURN_RATE process mode started")
             end
 
             local unallocated = _allocate_burn_rate(self.burn_target, true)
@@ -459,7 +461,7 @@ function facility.new(num_reactors, cooling_conf)
                 self.accumulator = 0
 
                 self.status_text = { "CHARGE MODE", "running control loop" }
-                log.info(util.c("FAC: CHARGE mode starting PID control"))
+                log.info("FAC: CHARGE mode starting PID control")
             elseif self.last_update ~= charge_update then
                 -- convert to kFE to make constants not microscopic
                 local error = util.round((self.charge_setpoint - avg_charge) / 1000) / 1000
@@ -614,7 +616,7 @@ function facility.new(num_reactors, cooling_conf)
             astatus.matrix_fill = (db.tanks.energy_fill >= ALARM_LIMS.CHARGE_HIGH) or (astatus.matrix_fill and db.tanks.energy_fill > ALARM_LIMS.CHARGE_RE_ENABLE)
 
             if was_fill and not astatus.matrix_fill then
-                log.info("FAC: charge state of induction matrix entered acceptable range <= " .. (ALARM_LIMS.CHARGE_RE_ENABLE * 100) .. "%")
+                log.info(util.c("FAC: charge state of induction matrix entered acceptable range <= ", ALARM_LIMS.CHARGE_RE_ENABLE * 100, "%"))
             end
 
             -- check for critical unit alarms

--- a/supervisor/facility.lua
+++ b/supervisor/facility.lua
@@ -152,6 +152,8 @@ function facility.new(num_reactors, cooling_conf)
         table.insert(self.test_tone_states, false)
     end
 
+    -- PRIVATE FUNCTIONS --
+
     -- check if all auto-controlled units completed ramping
     ---@nodiscard
     local function _all_units_ramped()
@@ -228,7 +230,7 @@ function facility.new(num_reactors, cooling_conf)
     ---@class facility
     local public = {}
 
-    -- ADD/LINK DEVICES --
+    --#region Add/Link Devices
 
     -- link a redstone RTU session
     ---@param rs_unit unit_session
@@ -268,11 +270,9 @@ function facility.new(num_reactors, cooling_conf)
         for _, v in pairs(self.rtu_list) do util.filter_table(v, function (s) return s.get_session_id() ~= session end) end
     end
 
-    -- UPDATE --
+    --#endregion
 
-    -- supervisor sessions reporting the list of active RTU sessions
-    ---@param rtu_sessions table session list of all connected RTUs
-    function public.report_rtus(rtu_sessions) self.rtu_conn_count = #rtu_sessions end
+    --#region Update
 
     -- update (iterate) the facility management
     function public.update()
@@ -323,7 +323,7 @@ function facility.new(num_reactors, cooling_conf)
         -- Run Process Control --
         -------------------------
 
-        --#region Process Control
+        --#region
 
         local avg_charge = self.avg_charge.compute()
         local avg_inflow = self.avg_inflow.compute()
@@ -597,7 +597,7 @@ function facility.new(num_reactors, cooling_conf)
         -- Evaluate Automatic SCRAM --
         ------------------------------
 
-        --#region Automatic SCRAM
+        --#region
 
         local astatus = self.ascram_status
 
@@ -727,6 +727,8 @@ function facility.new(num_reactors, cooling_conf)
         -- Handle Redstone I/O --
         -------------------------
 
+        --#region
+
         if #self.redstone > 0 then
             -- handle facility SCRAM
             if self.io_ctl.digital_read(IO.F_SCRAM) then
@@ -756,9 +758,13 @@ function facility.new(num_reactors, cooling_conf)
             self.io_ctl.digital_write(IO.F_ALARM_ANY, has_any_alarm)
         end
 
+        --#endregion
+
         ----------------
         -- Unit Tasks --
         ----------------
+
+        --#region
 
         local insufficent_po_rate = false
         local need_emcool = false
@@ -798,9 +804,13 @@ function facility.new(num_reactors, cooling_conf)
             end
         end
 
+        --#endregion
+
         ------------------------
         -- Update Alarm Tones --
         ------------------------
+
+        --#region
 
         local allow_test = self.allow_testing and self.test_tone_set
 
@@ -888,6 +898,8 @@ function facility.new(num_reactors, cooling_conf)
             self.test_tone_set = false
             self.test_tone_reset = true
         end
+
+        --#endregion
     end
 
     -- call the update function of all units in the facility<br>
@@ -900,7 +912,9 @@ function facility.new(num_reactors, cooling_conf)
         end
     end
 
-    -- COMMANDS --
+    --#endregion
+
+    --#region Commands
 
     -- SCRAM all reactor units
     function public.scram_all()
@@ -988,7 +1002,9 @@ function facility.new(num_reactors, cooling_conf)
         }
     end
 
-    -- SETTINGS --
+    --#endregion
+
+    --#region Settings
 
     -- set the automatic control group of a unit
     ---@param unit_id integer unit ID
@@ -1029,7 +1045,9 @@ function facility.new(num_reactors, cooling_conf)
         return self.pu_fallback
     end
 
-    -- DIAGNOSTIC TESTING --
+    --#endregion
+
+    --#region Diagnostic Testing
 
     -- attempt to set a test tone state
     ---@param id TONE|0 tone ID or 0 to disable all
@@ -1069,7 +1087,9 @@ function facility.new(num_reactors, cooling_conf)
         return self.allow_testing, self.test_alarm_states
     end
 
-    -- READ STATES/PROPERTIES --
+    --#endregion
+
+    --#region Read States/Properties
 
     -- get current alarm tone on/off states
     ---@nodiscard
@@ -1182,6 +1202,12 @@ function facility.new(num_reactors, cooling_conf)
 
         return status
     end
+
+    --#endregion
+
+    -- supervisor sessions reporting the list of active RTU sessions
+    ---@param rtu_sessions table session list of all connected RTUs
+    function public.report_rtus(rtu_sessions) self.rtu_conn_count = #rtu_sessions end
 
     -- get the units in this facility
     ---@nodiscard

--- a/supervisor/startup.lua
+++ b/supervisor/startup.lua
@@ -21,7 +21,7 @@ local supervisor = require("supervisor.supervisor")
 
 local svsessions = require("supervisor.session.svsessions")
 
-local SUPERVISOR_VERSION = "v1.2.7"
+local SUPERVISOR_VERSION = "v1.2.8"
 
 local println = util.println
 local println_ts = util.println_ts

--- a/supervisor/startup.lua
+++ b/supervisor/startup.lua
@@ -21,7 +21,7 @@ local supervisor = require("supervisor.supervisor")
 
 local svsessions = require("supervisor.session.svsessions")
 
-local SUPERVISOR_VERSION = "v1.2.9"
+local SUPERVISOR_VERSION = "v1.2.10"
 
 local println = util.println
 local println_ts = util.println_ts
@@ -34,9 +34,13 @@ if not supervisor.load_config() then
     -- try to reconfigure (user action)
     local success, error = configure.configure(true)
     if success then
-        assert(supervisor.load_config(), "failed to load valid configuration")
+        if not supervisor.load_config() then
+            println("failed to load a valid configuration, please reconfigure")
+            return
+        end
     else
-        assert(success, "supervisor configuration error: " .. error)
+        println("configuration error: " .. error)
+        return
     end
 end
 

--- a/supervisor/startup.lua
+++ b/supervisor/startup.lua
@@ -21,7 +21,7 @@ local supervisor = require("supervisor.supervisor")
 
 local svsessions = require("supervisor.session.svsessions")
 
-local SUPERVISOR_VERSION = "v1.2.10"
+local SUPERVISOR_VERSION = "v1.2.11"
 
 local println = util.println
 local println_ts = util.println_ts

--- a/supervisor/startup.lua
+++ b/supervisor/startup.lua
@@ -21,7 +21,7 @@ local supervisor = require("supervisor.supervisor")
 
 local svsessions = require("supervisor.session.svsessions")
 
-local SUPERVISOR_VERSION = "v1.2.8"
+local SUPERVISOR_VERSION = "v1.2.9"
 
 local println = util.println
 local println_ts = util.println_ts

--- a/supervisor/supervisor.lua
+++ b/supervisor/supervisor.lua
@@ -199,9 +199,8 @@ function supervisor.comms(_version, nic, fp_ok)
                         -- pass the packet onto the session handler
                         session.in_queue.push_packet(packet)
                     else
-                        -- unknown session, force a re-link
-                        log.debug("PLC_ESTABLISH: no session but not an establish, forcing relink")
-                        _send_establish(packet.scada_frame, ESTABLISH_ACK.DENY)
+                        -- any other packet should be session related, discard it
+                        log.debug("discarding RPLC packet without a known session")
                     end
                 elseif protocol == PROTOCOL.SCADA_MGMT then
                     ---@cast packet mgmt_frame

--- a/supervisor/unit.lua
+++ b/supervisor/unit.lua
@@ -586,7 +586,7 @@ function unit.new(reactor_id, num_boilers, num_turbines)
     function public.auto_get_effective_limit()
         local ctrl = self.db.control
         if (not ctrl.ready) or ctrl.degraded or self.plc_cache.rps_trip then
-            log.debug(util.c("UNIT ", self.r_id, ": effective limit is zero! ready[", ctrl.ready, "] degraded[", ctrl.degraded, "] rps_trip[", self.plc_cache.rps_trip, "]"))
+            -- log.debug(util.c("UNIT ", self.r_id, ": effective limit is zero! ready[", ctrl.ready, "] degraded[", ctrl.degraded, "] rps_trip[", self.plc_cache.rps_trip, "]"))
             ctrl.br100 = 0
             return 0
         else return ctrl.lim_br100 end

--- a/supervisor/unit.lua
+++ b/supervisor/unit.lua
@@ -255,7 +255,7 @@ function unit.new(reactor_id, num_boilers, num_turbines)
 
     -- PRIVATE FUNCTIONS --
 
-    --#region time derivative utility functions
+    --#region Time Derivative Utility Functions
 
     -- compute a change with respect to time of the given value
     ---@param key string value key
@@ -330,7 +330,7 @@ function unit.new(reactor_id, num_boilers, num_turbines)
 
     --#endregion
 
-    --#region redstone I/O
+    --#region Redstone I/O
 
     -- create a generic valve interface
     ---@nodiscard
@@ -397,8 +397,7 @@ function unit.new(reactor_id, num_boilers, num_turbines)
     ---@class reactor_unit
     local public = {}
 
-    -- ADD/LINK DEVICES --
-    --#region
+    --#region Add/Link Devices
 
     -- link the PLC
     ---@param plc_session plc_session_struct
@@ -488,7 +487,7 @@ function unit.new(reactor_id, num_boilers, num_turbines)
 
     --#endregion
 
-    -- UPDATE SESSION --
+    --#region Update Session
 
     -- update (iterate) this unit
     function public.update()
@@ -556,8 +555,9 @@ function unit.new(reactor_id, num_boilers, num_turbines)
         end
     end
 
-    -- AUTO CONTROL OPERATIONS --
-    --#region
+    --#endregion
+
+    --#region Auto Control Operations
 
     -- engage automatic control
     function public.auto_engage()
@@ -644,8 +644,7 @@ function unit.new(reactor_id, num_boilers, num_turbines)
 
     --#endregion
 
-    -- OPERATIONS --
-    --#region
+    --#region Operations
 
     -- queue a command to disable the reactor
     function public.disable()
@@ -725,8 +724,7 @@ function unit.new(reactor_id, num_boilers, num_turbines)
 
     --#endregion
 
-    -- READ STATES/PROPERTIES --
-    --#region
+    --#region Read States/Properties
 
     -- check if an alarm of at least a certain priority level is tripped
     ---@nodiscard
@@ -877,7 +875,7 @@ function unit.new(reactor_id, num_boilers, num_turbines)
         return status
     end
 
-    -- get the current total [max] production rate is
+    -- get the current total max production rate
     ---@nodiscard
     ---@return number total_avail_rate
     function public.get_sna_rate()

--- a/supervisor/unit.lua
+++ b/supervisor/unit.lua
@@ -77,7 +77,6 @@ function unit.new(reactor_id, num_boilers, num_turbines)
         tanks = {},
         snas = {},
         envd = {},
-        sna_prod_rate = 0,
         -- redstone control
         io_ctl = nil,   ---@type rs_controller
         valves = {},    ---@type unit_valves
@@ -857,13 +856,15 @@ function unit.new(reactor_id, num_boilers, num_turbines)
             status.tanks[tank.get_device_idx()] = { tank.is_faulted(), db.formed, db.state, db.tanks }
         end
 
-        -- basic SNA statistical information
-        local total_peak = 0
+        -- SNA statistical information
+        local total_peak, total_avail, total_out = 0, 0, 0
         for i = 1, #self.snas do
             local db = self.snas[i].get_db()    ---@type sna_session_db
             total_peak = total_peak + db.state.peak_production
+            total_avail = total_avail + db.state.production_rate
+            total_out = total_out + math.min(db.tanks.input.amount / 10, db.state.production_rate)
         end
-        status.sna = { #self.snas, public.get_sna_rate(), total_peak }
+        status.sna = { #self.snas, total_peak, total_avail, total_out }
 
         -- radiation monitors (environment detectors)
         status.envds = {}

--- a/supervisor/unit.lua
+++ b/supervisor/unit.lua
@@ -564,6 +564,7 @@ function unit.new(reactor_id, num_boilers, num_turbines)
     function public.auto_engage()
         self.auto_engaged = true
         if self.plc_i ~= nil then
+            log.debug(util.c("UNIT ", self.r_id, ": engaged auto control"))
             self.plc_i.auto_lock(true)
         end
     end
@@ -572,6 +573,7 @@ function unit.new(reactor_id, num_boilers, num_turbines)
     function public.auto_disengage()
         self.auto_engaged = false
         if self.plc_i ~= nil then
+            log.debug(util.c("UNIT ", self.r_id, ": disengaged auto control"))
             self.plc_i.auto_lock(false)
             self.db.control.br100 = 0
         end
@@ -582,12 +584,12 @@ function unit.new(reactor_id, num_boilers, num_turbines)
     ---@nodiscard
     ---@return integer lim_br100
     function public.auto_get_effective_limit()
-        if (not self.db.control.ready) or self.db.control.degraded or self.plc_cache.rps_trip then
-            self.db.control.br100 = 0
+        local ctrl = self.db.control
+        if (not ctrl.ready) or ctrl.degraded or self.plc_cache.rps_trip then
+            log.debug(util.c("UNIT ", self.r_id, ": effective limit is zero! ready[", ctrl.ready, "] degraded[", ctrl.degraded, "] rps_trip[", self.plc_cache.rps_trip, "]"))
+            ctrl.br100 = 0
             return 0
-        else
-            return self.db.control.lim_br100
-        end
+        else return ctrl.lim_br100 end
     end
 
     -- set the automatic burn rate based on the last set burn rate in 100ths
@@ -595,8 +597,8 @@ function unit.new(reactor_id, num_boilers, num_turbines)
     function public.auto_commit_br100(ramp)
         if self.auto_engaged then
             if self.plc_i ~= nil then
+                log.debug(util.c("UNIT ", self.r_id, ": commit br100 of ", self.db.control.br100, " with ramp set to ", ramp))
                 self.plc_i.auto_set_burn(self.db.control.br100 / 100, ramp)
-
                 if ramp then self.ramp_target_br100 = self.db.control.br100 end
             end
         end

--- a/supervisor/unitlogic.lua
+++ b/supervisor/unitlogic.lua
@@ -54,9 +54,7 @@ function logic.update_annunciator(self)
     -- variables for boiler, or reactor if no boilers used
     local total_boil_rate = 0.0
 
-    -------------
-    -- REACTOR --
-    -------------
+    --#region Reactor
 
     annunc.AutoControl = self.auto_engaged
 
@@ -143,9 +141,9 @@ function logic.update_annunciator(self)
         self.plc_cache.ok = false
     end
 
-    ---------------
-    -- MISC RTUs --
-    ---------------
+    --#endregion
+
+    --#region Misc RTUs
 
     local max_rad, any_faulted = 0, false
 
@@ -170,9 +168,9 @@ function logic.update_annunciator(self)
         end
     end
 
-    -------------
-    -- BOILERS --
-    -------------
+    --#endregion
+
+    --#region Boilers
 
     local boilers_ready = num_boilers == #self.boilers
 
@@ -230,9 +228,9 @@ function logic.update_annunciator(self)
         boiler_water_dt_sum = _get_dt(DT_KEYS.ReactorCCool)
     end
 
-    ---------------------------
-    -- COOLANT FEED MISMATCH --
-    ---------------------------
+    --#endregion
+
+    --#region Coolant Feed Mismatch
 
     -- check coolant feed mismatch if using boilers, otherwise calculate with reactor
     local cfmismatch = false
@@ -263,9 +261,9 @@ function logic.update_annunciator(self)
 
     annunc.CoolantFeedMismatch = cfmismatch
 
-    --------------
-    -- TURBINES --
-    --------------
+    --#endregion
+
+    --#region Turbines
 
     local turbines_ready = num_turbines == #self.turbines
 
@@ -339,6 +337,8 @@ function logic.update_annunciator(self)
         local has_steam = db.state.steam_input_rate > 0 or db.tanks.steam_fill > 0.01
         annunc.TurbineTrip[idx] = has_steam and db.state.flow_rate == 0
     end
+
+    --#endregion
 
     -- update auto control ready state for this unit
     self.db.control.ready = plc_ready and boilers_ready and turbines_ready

--- a/test/watch_psil_allocs.lua
+++ b/test/watch_psil_allocs.lua
@@ -1,0 +1,56 @@
+-- add this to psil:
+
+--[[
+    -- count the number of subscribers in this PSIL instance
+    ---@return integer count
+    function public.count()
+        local c = 0
+        for _, val in pairs(ic) do
+            for _ = 1, #val.subscribers do c = c + 1 end
+        end
+        return c
+    end
+]]--
+
+
+-- add this to coordinator iocontrol front panel heartbeat function:
+
+--[[
+if io.facility then
+    local count = io.facility.ps.count()
+
+    count = count + io.facility.env_d_ps.count()
+
+    for x = 1, #io.facility.induction_ps_tbl do
+        count = count + io.facility.induction_ps_tbl[x].count()
+    end
+
+    for x = 1, #io.facility.sps_ps_tbl do
+        count = count + io.facility.sps_ps_tbl[x].count()
+    end
+
+    for x = 1, #io.facility.tank_ps_tbl do
+        count = count + io.facility.tank_ps_tbl[x].count()
+    end
+
+    for i = 1, #io.units do
+        local entry = io.units[i] ---@type ioctl_unit
+
+        count = count + entry.unit_ps.count()
+
+        for x = 1, #entry.boiler_ps_tbl do
+            count = count + entry.boiler_ps_tbl[x].count()
+        end
+
+        for x = 1, #entry.turbine_ps_tbl do
+            count = count + entry.turbine_ps_tbl[x].count()
+        end
+
+        for x = 1, #entry.tank_ps_tbl do
+            count = count + entry.tank_ps_tbl[x].count()
+        end
+    end
+
+    log.debug(count)
+end
+]]--


### PR DESCRIPTION
#### Feature Changes & Bug Fixes
- #387 handle coordinator monitor resizes
- #328 K, °C, °F, and °R temperature unit options on the coordinator monitors
- fixed HMAC not being cleared for supervisor connection if going back and clearing the key in the coordinator configurator
- #430 fixed boiler, turbine, and tank status indicators from flickering "OFF-LINE" briefly
- #433 changed coordinator connection timeout to supervisor to use `os.clock()` so that it is more tolerant to lag at startup
- #432 wait 30s before assuming monitors are not setup right at computer start in case the chunks with monitors haven't loaded yet
- #431 fixed uncommon case of reactor PLC entering a non-functional state due to a race condition with the reactor being unformed
- #441 fixed PPM not reporting the right error on undefined functions
- #438 accurately report polonium production rates per the SNA rather than an estimate based on waste rates
- #442 print and exit rather than asserting on bad configurations

#### Version Changes
- Comms 2.4.4 to 2.4.5
- Common 1.1.14 to 1.1.18
- Graphics 2.1.0 to 2.1.1
- Reactor PLC v1.6.11 to v1.6.14
- RTU v1.7.13 to v1.7.14
- Supervisor v1.2.8 to v1.2.11
- Coordinator v1.2.2 to v1.2.11
- Pocket v0.7.0-alpha to v0.7.1-alpha