### PR TITLE
2025.11.20 Beta Patch

### DIFF
--- a/reactor-plc/startup.lua
+++ b/reactor-plc/startup.lua
@@ -18,7 +18,7 @@ local plc       = require("reactor-plc.plc")
 local renderer  = require("reactor-plc.renderer")
 local threads   = require("reactor-plc.threads")
 
-local R_PLC_VERSION = "v1.9.0"
+local R_PLC_VERSION = "v1.9.1"
 
 local println = util.println
 local println_ts = util.println_ts
@@ -89,7 +89,7 @@ local function main()
         plc_state = {
             fp_ok = false,
             shutdown = false,
-            degraded = true,
+            degraded = false,
             reactor_formed = true,
             no_reactor = true,
             no_modem = true


### PR DESCRIPTION
Minor patch to degraded status initialization on the Reactor PLC to resolve a purely cosmetic/graphical issue in the last hotfix due to a non-standard release sequence.

### Summary

- #652 Fixed Reactor PLC degraded init state.

### Version Patch

- Reactor PLC v1.9.0 to **v1.9.1**

### Installation without HTTP

Release bundles are attached below! Read how to use them [here](https://github.com/MikaylaFischler/cc-mek-scada/wiki/Alternative-Installation-Strategies#release-bundles).