### PR TITLE
2026.07.05 Beta Hotfix

### DIFF
--- a/coordinator/config/system.lua
+++ b/coordinator/config/system.lua
@@ -75,7 +75,6 @@ function system.create(tool_ctl, main_pane, cfg_sys, divs, ext, style)
     TextBox{parent=net_cfg,y=2,text=" Network Configuration",fg_bg=cpair(colors.black,colors.lightBlue)}
 
     TextBox{parent=net_c_1,y=1,text="Please select the network interface(s)."}
-    TextBox{parent=net_c_1,x=41,y=1,text="new!",fg_bg=cpair(colors.red,colors._INHERIT)}  ---@todo remove NEW tag on next revision
 
     local function on_wired_change(_) tool_ctl.gen_modem_list() end
 
@@ -127,11 +126,9 @@ function system.create(tool_ctl, main_pane, cfg_sys, divs, ext, style)
 
     TextBox{parent=net_c_2,text="If you selected multiple interfaces, please specify if this device should prefer wireless or otherwise wired. The preferred interface is switched too when reconnected even if failover has succeeded onto the fallback interface."}
     self.wl_pref = Checkbox{parent=net_c_2,y=7,label="Prefer Wireless",default=ini_cfg.PreferWireless,box_fg_bg=cpair(colors.lightBlue,colors.black),disable_fg_bg=g_lg_fg_bg}
-    TextBox{parent=net_c_2,x=19,y=7,text="new!",fg_bg=cpair(colors.red,colors._INHERIT)}  ---@todo remove NEW tag on next revision
 
     TextBox{parent=net_c_2,y=9,text="With a wireless modem, configure Pocket access."}
     self.api_en = Checkbox{parent=net_c_2,y=11,label="Enable Pocket Access",default=ini_cfg.API_Enabled,box_fg_bg=cpair(colors.lightBlue,colors.black),disable_fg_bg=g_lg_fg_bg}
-    TextBox{parent=net_c_2,x=24,y=11,text="new!",fg_bg=cpair(colors.red,colors._INHERIT)}  ---@todo remove NEW tag on next revision
 
     local function submit_net_cfg_opts()
         if tmp_cfg.WirelessModem and tmp_cfg.WiredModem then

--- a/coordinator/startup.lua
+++ b/coordinator/startup.lua
@@ -20,7 +20,7 @@ local renderer    = require("coordinator.renderer")
 local sounder     = require("coordinator.sounder")
 local threads     = require("coordinator.threads")
 
-local COORDINATOR_VERSION = "v1.9.1"
+local COORDINATOR_VERSION = "v1.9.2"
 
 local CHUNK_LOAD_DELAY_S = 30.0
 

--- a/coordinator/startup.lua
+++ b/coordinator/startup.lua
@@ -20,7 +20,7 @@ local renderer    = require("coordinator.renderer")
 local sounder     = require("coordinator.sounder")
 local threads     = require("coordinator.threads")
 
-local COORDINATOR_VERSION = "v1.9.3"
+local COORDINATOR_VERSION = "v1.9.4"
 
 local CHUNK_LOAD_DELAY_S = 30.0
 

--- a/coordinator/startup.lua
+++ b/coordinator/startup.lua
@@ -20,7 +20,7 @@ local renderer    = require("coordinator.renderer")
 local sounder     = require("coordinator.sounder")
 local threads     = require("coordinator.threads")
 
-local COORDINATOR_VERSION = "v1.9.2"
+local COORDINATOR_VERSION = "v1.9.3"
 
 local CHUNK_LOAD_DELAY_S = 30.0
 

--- a/coordinator/ui/layout/flow_view.lua
+++ b/coordinator/ui/layout/flow_view.lua
@@ -55,6 +55,7 @@ local function init(main)
     local tank_types = fac.tank_fluid_types
 
     local com_waste = fac.combined_waste
+    local com_waste_y_ofs = #units + 1
 
     -- window header message
     local header = TextBox{parent=main,y=1,text="Facility Coolant and Waste Flow Monitor",alignment=ALIGN.CENTER,fg_bg=style.theme.header}
@@ -154,7 +155,7 @@ local function init(main)
 
                 if i == first_fdef then
                     if compressed_view then
-                        y = y_ofs(5) - 7
+                        y = y_ofs(com_waste_y_ofs) - 7
                         table.insert(emcool_pipes, pipe(0, y - 3, 1, y + 5, c_clr(i), true))
                     else
                         table.insert(emcool_pipes, pipe(0, y, 1, y + 5, c_clr(i), true))
@@ -318,7 +319,7 @@ local function init(main)
     ---------------------------------
 
     if com_waste then
-        local waste = Div{parent=main,x=flow_x,y=y_ofs(5)+tri(compressed_view,3,-6),width=tri(no_tanks,139,117),height=11}
+        local waste = Div{parent=main,x=flow_x,y=y_ofs(com_waste_y_ofs)+tri(compressed_view,3,-6),width=tri(no_tanks,139,117),height=11}
 
         waste_flow(waste, 18, 1, no_tanks, com_waste, { "pu", "po", "pl", "am" }, { "PV01-PU", "PV02-PO", "PV03-PL", "PV04-AM" }, fac.ps)
 
@@ -329,7 +330,7 @@ local function init(main)
 
         TextBox{parent=waste,x=1,y=2,text="\x1a",fg_bg=cpair(colors.brown,text_c.bkg),width=1}
 
-        PipeNetwork{parent=main,x=141,y=15,pipes={pipe(0,y_ofs(5)-tri(compressed_view,4,13),2,0,colors.green,true,true)},bg=style.theme.bg}
+        PipeNetwork{parent=main,x=141,y=15,pipes={pipe(0,y_ofs(com_waste_y_ofs)-tri(compressed_view,4,13),2,0,colors.green,true,true)},bg=style.theme.bg}
     else
         PipeNetwork{parent=main,x=139,y=15,pipes=po_pipes,bg=style.theme.bg}
     end
@@ -404,7 +405,7 @@ local function init(main)
 
             if tank_list[i] == 2 and compressed_view then
                 -- this only is possible with tank mode 1, so assume that and send the tank to the bottom
-                y_offset = y_ofs(5) - 7
+                y_offset = y_ofs(com_waste_y_ofs) - 7
             end
 
             local tank = Div{parent=main,x=3,y=7+y_offset,width=20,height=14}

--- a/coordinator/ui/layout/flow_view.lua
+++ b/coordinator/ui/layout/flow_view.lua
@@ -55,7 +55,6 @@ local function init(main)
     local tank_types = fac.tank_fluid_types
 
     local com_waste = fac.combined_waste
-    local com_waste_y_ofs = #units + 1
 
     -- window header message
     local header = TextBox{parent=main,y=1,text="Facility Coolant and Waste Flow Monitor",alignment=ALIGN.CENTER,fg_bg=style.theme.header}
@@ -89,6 +88,9 @@ local function init(main)
         req_height = tri(compressed_view, (11 * #units) + 13, (19 * #units) + 4)
     end
 
+    -- waste stats extend down 31 (+1 for padding)
+    req_height = math.max(32, req_height)
+
     assert(main.get_height() >= req_height, "flow display not of sufficient vertical resolution (add an additional row of monitors)")
 
     -- get the y offset for this unit index
@@ -112,6 +114,9 @@ local function init(main)
         end
         return first, last
     end
+
+    -- a little extra padding for single unit to not conflict with SPS block
+    local com_waste_y_ofs = tri(#units > 1, y_ofs(#units + 1), 13)
 
     if fac.tank_mode == 0 or fac.tank_mode == 8 then
         -- (0) tanks belong to reactor units OR (8) 4 total facility tanks (A B C D)
@@ -155,7 +160,7 @@ local function init(main)
 
                 if i == first_fdef then
                     if compressed_view then
-                        y = y_ofs(com_waste_y_ofs) - 7
+                        y = com_waste_y_ofs - 7
                         table.insert(emcool_pipes, pipe(0, y - 3, 1, y + 5, c_clr(i), true))
                     else
                         table.insert(emcool_pipes, pipe(0, y, 1, y + 5, c_clr(i), true))
@@ -319,7 +324,7 @@ local function init(main)
     ---------------------------------
 
     if com_waste then
-        local waste = Div{parent=main,x=flow_x,y=y_ofs(com_waste_y_ofs)+tri(compressed_view,3,-6),width=tri(no_tanks,139,117),height=11}
+        local waste = Div{parent=main,x=flow_x,y=com_waste_y_ofs+tri(compressed_view,3,-6),width=tri(no_tanks,139,117),height=11}
 
         waste_flow(waste, 18, 1, no_tanks, com_waste, { "pu", "po", "pl", "am" }, { "PV01-PU", "PV02-PO", "PV03-PL", "PV04-AM" }, fac.ps)
 
@@ -330,7 +335,7 @@ local function init(main)
 
         TextBox{parent=waste,x=1,y=2,text="\x1a",fg_bg=cpair(colors.brown,text_c.bkg),width=1}
 
-        PipeNetwork{parent=main,x=141,y=15,pipes={pipe(0,y_ofs(com_waste_y_ofs)-tri(compressed_view,4,13),2,0,colors.green,true,true)},bg=style.theme.bg}
+        PipeNetwork{parent=main,x=141,y=15,pipes={pipe(0,com_waste_y_ofs-tri(compressed_view,4,13),2,0,colors.green,true,true)},bg=style.theme.bg}
     else
         PipeNetwork{parent=main,x=139,y=15,pipes=po_pipes,bg=style.theme.bg}
     end
@@ -405,7 +410,7 @@ local function init(main)
 
             if tank_list[i] == 2 and compressed_view then
                 -- this only is possible with tank mode 1, so assume that and send the tank to the bottom
-                y_offset = y_ofs(com_waste_y_ofs) - 7
+                y_offset = com_waste_y_ofs - 7
             end
 
             local tank = Div{parent=main,x=3,y=7+y_offset,width=20,height=14}

--- a/pocket/config/system.lua
+++ b/pocket/config/system.lua
@@ -63,7 +63,6 @@ function system.create(tool_ctl, main_pane, cfg_sys, divs, style, startup, exit)
     TextBox{parent=ui_c_1,y=1,height=3,text="You may customize UI options below."}
 
     TextBox{parent=ui_c_1,y=4,text="Po/Pu Pellet Color"}
-    TextBox{parent=ui_c_1,x=20,y=4,text="new!",fg_bg=cpair(colors.red,colors._INHERIT)}  ---@todo remove NEW tag on next revision
     local pellet_color = RadioButton{parent=ui_c_1,y=5,default=util.trinary(ini_cfg.GreenPuPellet,1,2),options={"Green Pu/Cyan Po","Cyan Pu/Green Po"},radio_colors=cpair(colors.lightGray,colors.black),select_color=colors.lime}
 
     TextBox{parent=ui_c_1,y=8,height=4,text="In Mekanism 10.4 and later, pellet colors now match gas colors (Cyan Pu/Green Po).",fg_bg=g_lg_fg_bg}

--- a/pocket/startup.lua
+++ b/pocket/startup.lua
@@ -22,7 +22,7 @@ local pocket    = require("pocket.pocket")
 local renderer  = require("pocket.renderer")
 local threads   = require("pocket.threads")
 
-local POCKET_VERSION = "v1.2.1"
+local POCKET_VERSION = "v1.2.2"
 
 local println = util.println
 local println_ts = util.println_ts

--- a/reactor-plc/config/system.lua
+++ b/reactor-plc/config/system.lua
@@ -260,7 +260,6 @@ function system.create(tool_ctl, main_pane, cfg_sys, divs, style, startup, exit)
     TextBox{parent=net_cfg,y=2,text=" Network Configuration",fg_bg=cpair(colors.black,colors.lightBlue)}
 
     TextBox{parent=net_c_1,y=1,text="Please select the network interface(s)."}
-    TextBox{parent=net_c_1,x=41,y=1,text="new!",fg_bg=cpair(colors.red,colors._INHERIT)}  ---@todo remove NEW tag on next revision
 
     local function en_dis_pref()
         if self.wireless.get_value() and self.wired.get_value() then

--- a/reactor-plc/startup.lua
+++ b/reactor-plc/startup.lua
@@ -19,7 +19,7 @@ local plc       = require("reactor-plc.plc")
 local renderer  = require("reactor-plc.renderer")
 local threads   = require("reactor-plc.threads")
 
-local R_PLC_VERSION = "v1.12.12"
+local R_PLC_VERSION = "v1.12.13"
 
 local println = util.println
 local println_ts = util.println_ts

--- a/rtu/config/system.lua
+++ b/rtu/config/system.lua
@@ -101,7 +101,6 @@ function system.create(tool_ctl, main_pane, cfg_sys, divs, ext, style)
     TextBox{parent=net_cfg,y=2,text=" Network Configuration",fg_bg=cpair(colors.black,colors.lightBlue)}
 
     TextBox{parent=net_c_1,y=1,text="Please select the network interface(s)."}
-    TextBox{parent=net_c_1,x=41,y=1,text="new!",fg_bg=cpair(colors.red,colors._INHERIT)}  ---@todo remove NEW tag on next revision
 
     local function en_dis_pref()
         if self.wireless.get_value() and self.wired.get_value() then

--- a/rtu/startup.lua
+++ b/rtu/startup.lua
@@ -21,7 +21,7 @@ local rtu       = require("rtu.rtu")
 local threads   = require("rtu.threads")
 local uinit     = require("rtu.uinit")
 
-local RTU_VERSION = "v1.14.1"
+local RTU_VERSION = "v1.14.2"
 
 local println = util.println
 local println_ts = util.println_ts

--- a/supervisor/config/facility.lua
+++ b/supervisor/config/facility.lua
@@ -759,7 +759,7 @@ function facility.create(tool_ctl, main_pane, cfg_sys, fac_cfg, style)
     --#region Combined Facility Waste
 
     TextBox{parent=fac_c_11,height=3,text="The standard setup expects waste processing (SNAs and PRCs) to be per-unit for statistics and individual Pu fallback management."}
-    TextBox{parent=fac_c_11,y=5,height=3,text="If your setup combines all raw waste before processing, please select combined facility waste management below."}
+    TextBox{parent=fac_c_11,y=5,height=3,text="If your setup combines all nuclear waste from MULTIPLE units before processing, please select combined facility waste management below."}
     TextBox{parent=fac_c_11,y=9,text="Both options expect one combined facility SPS.",fg_bg=g_lg_fg_bg}
 
     tool_ctl.com_waste = Checkbox{parent=fac_c_11,y=11,label="Combined Facility Waste",default=ini_cfg.CombinedWaste,box_fg_bg=cpair(colors.yellow,colors.black)}

--- a/supervisor/config/facility.lua
+++ b/supervisor/config/facility.lua
@@ -743,6 +743,7 @@ function facility.create(tool_ctl, main_pane, cfg_sys, fac_cfg, style)
     TextBox{parent=fac_c_10,y=5,height=3,text="If you are not using SNAs, you can unselect this option to have the Supervisor compute an estimate based on the current burn rate."}
 
     tool_ctl.sna_stats = Checkbox{parent=fac_c_10,y=9,label="Use SNAs for Po Statistics",default=ini_cfg.UseSNAStatistics,box_fg_bg=cpair(colors.yellow,colors.black)}
+    TextBox{parent=fac_c_10,x=30,y=9,text="new!",fg_bg=cpair(colors.red,colors._INHERIT)}  ---@todo remove NEW tag on next revision
 
     TextBox{parent=fac_c_10,y=11,height=3,text="Both modes depend on correct waste ratios in the Mekanism Configuration section.",fg_bg=g_lg_fg_bg}
 
@@ -762,6 +763,7 @@ function facility.create(tool_ctl, main_pane, cfg_sys, fac_cfg, style)
     TextBox{parent=fac_c_11,y=9,text="Both options expect one combined facility SPS.",fg_bg=g_lg_fg_bg}
 
     tool_ctl.com_waste = Checkbox{parent=fac_c_11,y=11,label="Combined Facility Waste",default=ini_cfg.CombinedWaste,box_fg_bg=cpair(colors.yellow,colors.black)}
+    TextBox{parent=fac_c_11,x=27,y=11,text="new!",fg_bg=cpair(colors.red,colors._INHERIT)}  ---@todo remove NEW tag on next revision
 
     local function submit_com_waste()
         tmp_cfg.CombinedWaste = tool_ctl.com_waste.get_value()

--- a/supervisor/config/system.lua
+++ b/supervisor/config/system.lua
@@ -83,7 +83,6 @@ function system.create(tool_ctl, main_pane, cfg_sys, divs, fac_pane, mek_pane, s
     TextBox{parent=net_cfg,y=2,text=" Network Configuration",fg_bg=cpair(colors.black,colors.lightBlue)}
 
     TextBox{parent=net_c_1,y=1,text="Please select the network interface(s)."}
-    TextBox{parent=net_c_1,x=41,y=1,text="new!",fg_bg=cpair(colors.red,colors._INHERIT)}  ---@todo remove NEW tag on next revision
 
     local function on_wired_change(_) tool_ctl.gen_modem_list() end
 
@@ -121,7 +120,6 @@ function system.create(tool_ctl, main_pane, cfg_sys, divs, fac_pane, mek_pane, s
     PushButton{parent=net_c_1,x=44,y=14,text="Next \x1a",callback=submit_interfaces,fg_bg=nav_fg_bg,active_fg_bg=btn_act_fg_bg}
 
     TextBox{parent=net_c_2,y=1,text="Please assign device connection interfaces if you selected multiple network interfaces."}
-    TextBox{parent=net_c_2,x=39,y=2,text="new!",fg_bg=cpair(colors.red,colors._INHERIT)}  ---@todo remove NEW tag on next revision
     TextBox{parent=net_c_2,y=4,text="Reactor PLC\nRTU Gateway\nCoordinator",fg_bg=g_lg_fg_bg}
     local opts = { "Wireless", "Wired", "Both" }
     local plc_listen = Radio2D{parent=net_c_2,x=14,y=4,rows=1,columns=3,default=ini_cfg.PLC_Listen,options=opts,radio_colors=cpair(colors.lightGray,colors.black),select_color=colors.lightBlue,disable_color=colors.gray,disable_fg_bg=g_lg_fg_bg}
@@ -137,9 +135,7 @@ function system.create(tool_ctl, main_pane, cfg_sys, divs, fac_pane, mek_pane, s
 
     TextBox{parent=net_c_2,y=8,text="With a wireless modem, configure Pocket access."}
     local pkt_en = Checkbox{parent=net_c_2,y=10,label="Enable Pocket Access",default=ini_cfg.PocketEnabled,callback=on_pocket_en,box_fg_bg=cpair(colors.lightBlue,colors.black),disable_fg_bg=g_lg_fg_bg}
-    TextBox{parent=net_c_2,x=24,y=10,text="new!",fg_bg=cpair(colors.red,colors._INHERIT)}  ---@todo remove NEW tag on next revision
     self.pkt_test = Checkbox{parent=net_c_2,label="Enable Pocket Remote System Testing",default=ini_cfg.PocketTest,box_fg_bg=cpair(colors.lightBlue,colors.black),disable_fg_bg=g_lg_fg_bg}
-    TextBox{parent=net_c_2,x=39,y=11,text="new!",fg_bg=cpair(colors.red,colors._INHERIT)}  ---@todo remove NEW tag on next revision
     TextBox{parent=net_c_2,x=3,text="This allows remotely playing alarm sounds.",fg_bg=g_lg_fg_bg}
 
     local function submit_net_cfg_opts()

--- a/supervisor/startup.lua
+++ b/supervisor/startup.lua
@@ -25,7 +25,7 @@ local supervisor = require("supervisor.supervisor")
 
 local svsessions = require("supervisor.session.svsessions")
 
-local SUPERVISOR_VERSION = "v1.11.4"
+local SUPERVISOR_VERSION = "v1.11.5"
 
 local println = util.println
 local println_ts = util.println_ts


### PR DESCRIPTION
This is a quick hotfix update for the previous release due to some issues missed in testing. The issue only impacts systems using Combined Facility Waste with less than 4 units.

### New Features & Improvements

- #753 Updated `new!` tags in configurators (removed old ones, added new ones for previous release). This is the only change in non-Coordinator code in this update.

### Bug Fixes

- #754 Fixed instances of hard-coded offsets for combined facility waste rendering.

### Known Issues

See wiki for longer standing compatibility issues: https://github.com/MikaylaFischler/cc-mek-scada/wiki/Known-Issues.

### Config Changes

None.

### Component Version Updates

- Reactor PLC v1.12.12 to **v1.12.13**
- RTU Gateway v1.14.1 to **v1.14.2**
- Supervisor v1.11.4 to **v1.11.5**
- Coordinator v1.9.1 to **v1.9.4**
- Pocket v1.2.1 to **v1.2.2**